### PR TITLE
Add language to turn on Control by mobile apps

### DIFF
--- a/com.funky.rokuremotejs.sdPlugin/pi/main_pi.html
+++ b/com.funky.rokuremotejs.sdPlugin/pi/main_pi.html
@@ -27,6 +27,12 @@
 
 
         </br>
+
+        <!-- message about roku update 14.1 -->
+        <details class="message">
+            <summary>On Roku version 14.1 you will need to turn on the "Control by moible apps" setting. Navigate to "Settings > System > Advanced system settings > Control by mobile apps" and set the Network access to "enabled".</summary>
+        </details>
+                
         </br>
 
         <!-- message about where to get help if needed -->


### PR DESCRIPTION
added a text box to the Roku Remote action describing the additional setting for Control by mobile apps that must be turned on in order to user the Roku app on stream deck.